### PR TITLE
feat!: add health route & move storage routes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ psycopg2-binary = "~=2.9"
 six = "~=1.16"
 tzdata = "~=2021.5"
 "ufile.io" = "~=1.0"
+django-health-check = "*"
+psutil = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dff2f0297f6c37b92b3ea971d72b5650527185a19578ad79def627aa8cd6c6a4"
+            "sha256": "b7d416d9e22576fc6a28088cd4a7e25c1af3894ea986de7358618b378dd4c0a1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -282,6 +282,14 @@
             "index": "pypi",
             "version": "==3.11.0"
         },
+        "django-health-check": {
+            "hashes": [
+                "sha256:1edfd49293ccebbce29f9da609c407f307aee240ab799ab4201031341ae78c0f",
+                "sha256:8d66781a0ea82b1a8b44878187b38a27370e94f18287312e39be0593e72d8983"
+            ],
+            "index": "pypi",
+            "version": "==3.16.5"
+        },
         "djangorestframework": {
             "hashes": [
                 "sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee",
@@ -443,6 +451,44 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.2.0"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5",
+                "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a",
+                "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4",
+                "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841",
+                "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d",
+                "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d",
+                "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0",
+                "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845",
+                "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf",
+                "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b",
+                "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07",
+                "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618",
+                "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2",
+                "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd",
+                "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666",
+                "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce",
+                "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3",
+                "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d",
+                "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25",
+                "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492",
+                "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b",
+                "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d",
+                "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2",
+                "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203",
+                "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2",
+                "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94",
+                "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9",
+                "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64",
+                "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56",
+                "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3",
+                "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c",
+                "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"
+            ],
+            "index": "pypi",
+            "version": "==5.9.0"
         },
         "psycopg2-binary": {
             "hashes": [

--- a/stowdo/storage/apps.py
+++ b/stowdo/storage/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class StorageConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'storage'
+    label = 'stowdo_storage'

--- a/stowdo/storage/urls.py
+++ b/stowdo/storage/urls.py
@@ -6,6 +6,4 @@ router = routers.DefaultRouter()
 router.register('resources', views.ResourceViewSet, basename='resource')
 router.register('folders', views.FolderViewSet, basename='folder')
 router.register('files', views.FileViewSet, basename='file')
-
-user_router = routers.DefaultRouter()
-user_router.register('users', views.UserViewSet, basename='user')
+router.register('users', views.UserViewSet, basename='user')

--- a/stowdo/stowdo/settings.py
+++ b/stowdo/stowdo/settings.py
@@ -57,6 +57,10 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'dj_rest_auth',
     'dj_rest_auth.registration',
+    'health_check',
+    'health_check.db',
+    'health_check.storage',
+    'health_check.contrib.psutil',
     'storage',
 ]
 LANGUAGE_CODE = 'fr-fr'

--- a/stowdo/stowdo/urls.py
+++ b/stowdo/stowdo/urls.py
@@ -2,15 +2,12 @@ from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
 
-from storage.urls import router as storage_router, user_router
-
-router = routers.DefaultRouter()
-router.registry.extend(storage_router.registry)
+from storage.urls import router as storage_router
 
 urlpatterns = [
-    path('', include(user_router.urls)),
+    path('', include(storage_router.urls)),
     path('admin/', admin.site.urls),
-    path('storage/', include(router.urls)),
     path('auth/', include('dj_rest_auth.urls')),
-    path('auth/register/', include('dj_rest_auth.registration.urls'))
+    path('auth/register/', include('dj_rest_auth.registration.urls')),
+    path('health/', include('health_check.urls')),
 ]


### PR DESCRIPTION
BREAKING CHANGES: storage related routes (resources, folders, files and users) have been moved

- /storage/resources/ -> /resources/

- /storage/folders/ -> /folders/

- /storage/files/ -> /files/

- /storage/users/ -> /users/